### PR TITLE
Remove origins that cause false failures for get_move test

### DIFF
--- a/agent_test.py
+++ b/agent_test.py
@@ -510,8 +510,8 @@ class Project1Test(unittest.TestCase):
         # performs an iterative deepening minimax search (minimax is easier to
         # test because it always visits all nodes in the game tree at every
         # level).
-        origins = [(2, 3), (6, 6), (7, 4), (4, 2), (0, 5), (10, 10)]
-        exact_counts = [(8, 8), (32, 10), (160, 39), (603, 35), (1861, 54), (3912, 62)]
+        origins = [(2, 3), (6, 6), (4, 2), (0, 5)]
+        exact_counts = [(8, 8), (32, 10), (603, 35), (1861, 54)]
 
         for idx in range(len(origins)):
 


### PR DESCRIPTION
(7,4) allows the center square 5,5 to be in the set of legal moves.  So test will fail if the agent has this opening move.

(10,10) will fail if the agent uses symmetry to avoid calling forecast_move.