### PR TITLE
Update forfeit count in tournament.py

### DIFF
--- a/tournament.py
+++ b/tournament.py
@@ -65,7 +65,7 @@ def play_round(cpu_agent, test_agents, win_counts, num_matches):
 
         if termination == "timeout":
             timeout_count += 1
-        elif winner not in test_agents and termination == "forfeit":
+        elif winner not in {agent.player for agent in test_agents} and termination == "forfeit":
             forfeit_count += 1
 
     return timeout_count, forfeit_count


### PR DESCRIPTION
The statement `winner not in test_agents` always evaluates to `True`, because `winner` is a `Player` instance and `test_agents` is a list of `Agents`.